### PR TITLE
The command line is now used to input the file as an argument

### DIFF
--- a/apt_decoder.py
+++ b/apt_decoder.py
@@ -1,0 +1,43 @@
+# derived from the base code at :
+# https://medium.com/swlh/decoding-noaa-satellite-images-using-50-lines-of-code3c5d1d0a08da
+import numpy as np
+import scipy.io.wavfile as wav
+import scipy.signal as signal
+from PIL import Image
+import sys
+
+
+# hilbert transform definition to get the amplitude envelope of the data
+def hilbert(data_sample):
+    analytical_signal = signal.hilbert(data_sample)
+    amplitude_envelope = np.abs(analytical_signal)
+    return amplitude_envelope
+
+
+# set sampling frequency and get data from input .wav file
+input_file_name = sys.argv[1]
+fs, data = wav.read(f'wav/{input_file_name}')
+data_am = hilbert(data)  # get the amplitude envelope of data signal
+
+frame_width = int(0.5 * fs)
+w, h = frame_width, data_am.shape[0] // frame_width
+image = Image.new('RGB', (w, h))
+
+px, py = 0, 0
+for p in range(data_am.shape[0]):
+    lum = int(data_am[p] // 32 - 32)
+    if lum < 0:
+        lum = 0
+    if lum > 255:
+        lum = 255
+    image.putpixel((px, py), (lum, lum, lum))
+    px += 1
+    if px >= w:
+        px = 0
+        py += 1
+        if py >= h:
+            break
+
+print(f"Finished. Image saved in output/{input_file_name[:-4]}.jpg")
+image = image.resize((w, h))
+image.save(f"output/{input_file_name[:-4]}.jpg")

--- a/apt_encoder.py
+++ b/apt_encoder.py
@@ -1,0 +1,146 @@
+import numpy as np
+import scipy.io.wavfile as wav
+import pgm_convert_and_resize
+import sys
+
+# Set wave parameters and initialize some global empty lists.
+carrier_hz = 2400      # NOAA specified AM carrier frequency
+apt_width = 909        # NOAA specified image width
+baud_rate = 4160       # NOAA APT baud rate (2 rows per second)
+stored_apt_pic = []    # List to store image pixels
+audio_sample = []      # List to store modulated sample data
+
+# Syncs for both image channels, as per the NOAA given standard
+sync_a = "000011001100110011001100110011000000000"
+sync_b = "000011100111001110011100111001110011100"
+
+
+# Return the pixel's position in the current row
+def get_pixel_position(row, col):
+    return col * apt_width + row
+
+
+# Ensure that the file is a P2 .PGM, encoded in LF format (i.e. '\n' newline)
+def image_load_and_check(file_name):
+    image_file = open(f'input/{file_name}', 'r')
+    get_line = image_file.readline()
+
+    try:
+        assert get_line[0] == 'P'
+        assert get_line[1] == '2'
+        assert get_line[2] == '\n'
+    except AssertionError:
+        print('Error. Must be a \'P2\' PGM file. Make sure the file is properly encoded in \'LF\' format')
+        quit()
+
+    get_line = image_file.readline()  # skip comments
+    while get_line[0] == '#':
+        get_line = image_file.readline()
+
+    try:
+        assert get_line[0] == '9'
+        assert get_line[1] == '0'
+        assert get_line[2] == '9'
+    except AssertionError:
+        print('Error. Image must have a width of 909 pixels.')
+        quit()
+    image_file.readline()
+    image_file = np.array(image_file.read().split('\n'))
+    return image_file
+
+
+# Start of the program, load image and make sure it is properly formatted for encoding
+input_file_name = sys.argv[1]
+
+if input_file_name.lower().endswith(('.png', '.jpg', '.jpeg')):
+    print("Not a PGM, converting...")
+    the_pgm_image = pgm_convert_and_resize.converter(input_file_name)
+    the_pgm_image = image_load_and_check('_created_by_temp_converter.pgm')
+elif input_file_name.lower().endswith('.pgm'):
+    print("PGM file, no conversion needed. (must be 909 pixels wide)")
+    the_pgm_image = image_load_and_check(input_file_name)
+else:
+    print("Error. Image must be a .pgm, .png, .jpg, or .jpeg extension")
+    quit()
+
+image_height = the_pgm_image.size // apt_width
+print("APT encoding started..")
+
+# Main loop, sending both pictures and sync/telemetry 1 row at a time, till the height of the picture as been reached.
+for rows in range(image_height):
+    image_frame_line = rows % 128
+
+    # Sync A
+    for index in sync_a:
+        if index == '0':
+            stored_apt_pic.append(0)
+        else:
+            stored_apt_pic.append(255)
+
+    # Space A
+    for index in range(47):
+        stored_apt_pic.append(0)
+
+    # Image A
+    for index in range(apt_width):
+        if rows < image_height:
+            stored_apt_pic.append(the_pgm_image[get_pixel_position(index, rows)])
+        else:
+            stored_apt_pic.append(0)
+
+    # Telemetry A
+    for index in range(45):
+        wedge = image_frame_line / 8
+        v = 0
+        if wedge < 8:
+            wedge += 1
+            v = int(255.0 * (wedge % 8 / 8.0))
+        stored_apt_pic.append(v)
+
+    # Sync B
+    for index in sync_b:
+        if index == '0':
+            stored_apt_pic.append(0)
+        else:
+            stored_apt_pic.append(255)
+
+    # Space B
+    for index in range(47):
+        stored_apt_pic.append(255)
+
+    # Image B
+    for index in range(apt_width):
+        if rows < image_height:
+            stored_apt_pic.append(the_pgm_image[get_pixel_position(index, rows)])
+        else:
+            stored_apt_pic.append(0)
+
+    # Telemetry B
+    for index in range(45):
+        wedge = image_frame_line / 8
+        v = 0
+        if wedge < 8:
+            wedge += 1
+            v = int(255.0 * (wedge % 8 / 8.0))
+        stored_apt_pic.append(v)
+
+stored_apt_pic = np.float64(stored_apt_pic)
+
+# Create the sine carrier sampling array with a length equal to the image array (total pixels)
+sine_carrier = np.sin(carrier_hz * 2.0 * np.pi * np.arange(len(stored_apt_pic)) / baud_rate)
+
+# Modulate audio sample, store in 16bit np array, multiply pixels by factor between 32-64
+audio_sample = np.int16(sine_carrier * stored_apt_pic * 42)
+
+# Save the encoded data into a .wav file
+wav_file_name = input_file_name[:-4]
+wav.write(f'wav/{wav_file_name}.wav', baud_rate, audio_sample)
+print(f"Finished, .wav file saved in Simple-APT/wav/{wav_file_name}.wav")
+
+# # Check out the finished picture as a .pgm
+# new_pgm_file = open("pics/example-pgm.pgm", "w+")
+# new_pgm_file.write("P2\n# apt pre-modulated image \n%d %d\n255\n" % (2080, 1606))
+#
+# for pixel in stored_apt_pic:
+#     new_pgm_file.write(str(pixel) + '\n')
+# new_pgm_file.close()

--- a/pgm_convert_and_resize.py
+++ b/pgm_convert_and_resize.py
@@ -1,0 +1,53 @@
+# pgm_convert_and_resize.py is a script for converting image types supported by PIL into their .pgm ascii
+# counterparts, as well as resizing the image to have a width of 909 and keeping the aspect ratio.
+# Its main purpose will be to feed NOAA-APT style images into an encoder program.
+from PIL import Image
+import numpy as np
+
+
+def converter(image):
+    # Open image, convert to greyscale, check width and resize if necessary
+    im = Image.open(f'input/{image}')
+    im = im.convert("L")
+
+    # image_array = np.array(im)
+    print(f"Size: {im.size}")      # Mode: {im.mode}")
+    # im.show()
+    if im.size != 909:
+        print("Resizing to width of 909 keeping aspect ratio...")
+        image_width = 909
+        wpercent = (image_width / float(im.size[0]))
+        hsize = int((float(im.size[1]) * float(wpercent)))
+        im = im.resize((image_width, hsize))
+        image_width, image_height = im.size
+        print(f"New Size: {im.size}")
+
+    # Save image data in a numpy array and make it 1D.
+    image_array1 = np.array(im).ravel()
+    # print(f"Picture Array: {image_array1}")
+
+    print(f"Saving as PGM...")
+    # Create file w .pgm ext to store data in, first 4 lines are: pgm type, comment, image size, maxVal
+    new_pgm_file = open("input/_created_by_temp_converter.pgm", "w+")
+    new_pgm_file.write("P2\n# created by pgm_convert_and_resize.py \n%d %d\n255\n" % im.size)
+
+    # Storing greyscale data in file with \n delimiter
+    for number in image_array1:
+        new_pgm_file.write(str(number) + '\n')
+    new_pgm_file.close()
+    # im = im.save(r"pics/IMG_0277-greyscale.jpg")
+
+    # replacement strings
+    windows_line_ending = b'\r\n'
+    unix_line_ending = b'\n'
+
+    # small code snippet that changes a Windows encoded text file into a Unix encoded one, or nothing if not.
+    with open('input/_created_by_temp_converter.pgm', 'rb') as new_pgm_file:
+        content = new_pgm_file.read()
+
+    content = content.replace(windows_line_ending, unix_line_ending)
+
+    with open('input/_created_by_temp_converter.pgm', 'wb') as new_pgm_file:
+        new_pgm_file.write(content)
+    new_pgm_file.close()
+    print(f"Finished")


### PR DESCRIPTION
Updated all three scripts, now apt_encoder.py uses pgm_convert_and_resize.py to allow the user to input any image file format supported by PIL. The command line is now used to input the file as an argument in both the encoder and decoder script, and the output file is saved with the same name as the input file, in the respective folder.

The input, output, and wav folders contain images and encoded wav examples.